### PR TITLE
Fix word-wrapping of the menu price in CantineActivity

### DIFF
--- a/app/src/main/java/com/main/dhbworld/CantineActivity.java
+++ b/app/src/main/java/com/main/dhbworld/CantineActivity.java
@@ -211,7 +211,8 @@ public class CantineActivity extends AppCompatActivity {
                 chipLayout.addView(chip);
             }
             LinearLayout preisLayout = new LinearLayout(CantineActivity.this);
-            preisLayout.setLayoutParams(new ViewGroup.LayoutParams(120, ViewGroup.LayoutParams.MATCH_PARENT));
+            preisLayout.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT));
+            preisLayout.setPadding(10, 0, 10, 0);
             preisLayout.setOrientation(LinearLayout.VERTICAL);
 
             TypedValue valuePreisBg = new TypedValue();


### PR DESCRIPTION
The fixed width of 120px on the preisLayout may cause word-wrapping on the menu price on some devices. Setting the layout width to WRAP_CONTENT should guarantee that the price is displayed in one line. To add some horizontal spacing around the price text, I added padding to the preisLayout.

Current behavior on my LG V30:
![Screenshot_20230206-181507](https://user-images.githubusercontent.com/29163322/217042547-3673b8c2-3686-4396-b724-75b97787496f.png)
